### PR TITLE
Improved error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,14 @@ function streamify(uri, opt) {
     :
     through();
 
-  new ffmpeg({source: video})
-    .on('error', function() {
+  var f = new ffmpeg({source: video})
+    .on('error', function(err) {
       video.end();
+      if (stream.listeners('error').length > 2) {
+        stream.emit('error', err);
+      } else {
+        throw new Error(err);
+      }
     })
     .toFormat(opt.audioFormat)
     .writeToStream(stream)

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ function streamify(uri, opt) {
     through();
 
   new ffmpeg({source: video})
+    .on('error', function() {
+      video.end();
+    })
     .toFormat(opt.audioFormat)
     .writeToStream(stream)
   ;


### PR DESCRIPTION
This branch handles input stream errors. Specifically, the following video is geo-restricted in the US:

https://www.youtube.com/watch?v=U8yJiLBQ-So

When I attempt to pipe a stream from this video, prior to this branch, the ffmpeg-fluent would throw an unhandled stream error. This branch quite simply handles the error, and destroys the stream in a safe way.