### PR TITLE
Put the ffmpeg process in a setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,13 +29,15 @@ function streamify (uri, opt) {
   const ffmpeg = new FFmpeg(video)
 
   process.nextTick(() => {
-    const output = ffmpeg.format(audioFormat).pipe(stream)
+    setTimeout(()=>{
+      const output = ffmpeg.format(audioFormat).pipe(stream)
 
-    ffmpeg.on('error', error => stream.emit('error', error))
-    output.on('error', error => {
-      video.end()
-      stream.emit('error', error)
-    })
+      ffmpeg.on('error', error => stream.emit('error', error))
+      output.on('error', error => {
+        video.end()
+        stream.emit('error', error)
+      })
+    });
   })
 
   stream.video = video


### PR DESCRIPTION
To avoid the maximum call stack range error when multiple simultaneous calls are made or even when used in a cue with only 1 worker.

I did time it and a 1h30 video and did not see any performance drop

 karim@karim-laptop  ~/Work/streamtube/xp  time node index.js 
node index.js  52,42s user 3,99s system 112% cpu 50,100 total
 karim@karim-laptop  ~/Work/streamtube/xp  time node index.js
node index.js  52,34s user 4,13s system 115% cpu 48,956 total